### PR TITLE
Fix login/signup redirects

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import MainLayout from '../components/layout/MainLayout';
 import AuthForm from '../components/auth/AuthForm';
 
 const Login = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const navigate = useNavigate();
   
   const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -25,7 +26,7 @@ const Login = () => {
       await new Promise(resolve => setTimeout(resolve, 1500));
       
       // Redirect to dashboard (in a real app, this would happen after successful authentication)
-      window.location.href = '/dashboard';
+      navigate('/dashboard');
     } catch (err) {
       setError('Invalid email or password. Please try again.');
       setIsLoading(false);

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import MainLayout from '../components/layout/MainLayout';
 import AuthForm from '../components/auth/AuthForm';
 
 const Signup = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const navigate = useNavigate();
   
   const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -33,7 +34,7 @@ const Signup = () => {
       await new Promise(resolve => setTimeout(resolve, 1500));
       
       // Redirect to dashboard (in a real app, this would happen after successful authentication)
-      window.location.href = '/dashboard';
+      navigate('/dashboard');
     } catch (err) {
       setError('Failed to create account. Please try again.');
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- fix login and signup pages to use SPA navigation via `useNavigate`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fc9dd8b1c83229c016d9a85550d86