### PR TITLE
Add cn util tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -77,6 +78,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0",
+    "@types/vitest": "^0.34.0"
   }
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { cn } from "./utils";
+
+describe("cn", () => {
+  it("joins class names", () => {
+    expect(cn("a", "b")).toBe("a b");
+  });
+
+  it("merges duplicate classes", () => {
+    expect(cn("a", "a", "b")).toBe("a b");
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["vitest"]
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
@@ -16,5 +16,8 @@ export default defineConfig(({ mode }) => ({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+  },
+  test: {
+    environment: "jsdom"
   },
 }));


### PR DESCRIPTION
## Summary
- install vitest and type definitions
- configure vitest in Vite
- enable vitest types in tsconfig
- add tests for `cn` utility

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdbb654a88322acdb1a809d36490e